### PR TITLE
Update Heading.jsx

### DIFF
--- a/src/components/Heading.jsx
+++ b/src/components/Heading.jsx
@@ -5,7 +5,7 @@ function Heading() {
     <header>
       <h1>Markdown Emoji Codes</h1>
       <div className="sub-header">
-        <h6>FIND YOUR FAVORITE ONE AND COPY WITH JUST ONE CLICK</h6>
+        <h6>FIND YOUR FAVORITE EMOJI AND COPY WITH JUST ONE CLICK</h6>
         <div className="github-stat">
           <a
             className="git-star"


### PR DESCRIPTION
You can not use `one` pronoun if you didnt mention the thing it refers to in an earlier sentence.